### PR TITLE
Get relations.py remove first column property

### DIFF
--- a/csv2rdf/get_relations.py
+++ b/csv2rdf/get_relations.py
@@ -28,11 +28,9 @@ try:
     with open(OUTPUT_NAME, "r", encoding="utf-8") as mapping:
         dt = json.load(mapping)
 except FileNotFoundError:
-    dt = {}
-    dt["entity_type"] = []
+    dt = {"entity_type" : []}
     
-dt_out = {}
-dt_out["entity_type"] = dt["entity_type"]
+dt_out = {"entity_type" : dt["entity_type"]}
 
 for filename in glob.glob(f"{FILEPATH}/{PATTERN}", recursive=False):
     with open(os.path.abspath(filename), "r", encoding="utf-8") as csv_file:

--- a/csv2rdf/get_relations.py
+++ b/csv2rdf/get_relations.py
@@ -32,6 +32,7 @@ except FileNotFoundError:
     dt["entity_type"] = []
     
 dt_out = {}
+dt_out["entity_type"] = dt["entity_type"]
 
 for filename in glob.glob(f"{FILEPATH}/{PATTERN}", recursive=False):
     with open(os.path.abspath(filename), "r", encoding="utf-8") as csv_file:
@@ -42,7 +43,7 @@ for filename in glob.glob(f"{FILEPATH}/{PATTERN}", recursive=False):
         if item not in dt.keys():
             dt_out[item] = ""
         else:
-            dt_out = dt[item]
+            dt_out[item] = dt[item]
 
 with open(OUTPUT_NAME, "w", encoding="utf-8") as out_json:
     json.dump(dt_out, out_json, indent=4)

--- a/csv2rdf/get_relations.py
+++ b/csv2rdf/get_relations.py
@@ -30,6 +30,8 @@ try:
 except FileNotFoundError:
     dt = {}
     dt["entity_type"] = []
+    
+dt_out = {}
 
 for filename in glob.glob(f"{FILEPATH}/{PATTERN}", recursive=False):
     with open(os.path.abspath(filename), "r", encoding="utf-8") as csv_file:
@@ -38,7 +40,9 @@ for filename in glob.glob(f"{FILEPATH}/{PATTERN}", recursive=False):
 
     for item in header:
         if item not in dt.keys():
-            dt[item] = ""
+            dt_out[item] = ""
+        else:
+            dt_out = dt[item]
 
 with open(OUTPUT_NAME, "w", encoding="utf-8") as out_json:
-    json.dump(dt, out_json, indent=4)
+    json.dump(dt_out, out_json, indent=4)

--- a/csv2rdf/get_relations.py
+++ b/csv2rdf/get_relations.py
@@ -34,7 +34,7 @@ except FileNotFoundError:
 for filename in glob.glob(f"{FILEPATH}/{PATTERN}", recursive=False):
     with open(os.path.abspath(filename), "r", encoding="utf-8") as csv_file:
         csv_reader = csv.reader(csv_file)
-        header = next(csv_reader)
+        header = next(csv_reader)[1:]
 
     for item in header:
         if item not in dt.keys():


### PR DESCRIPTION
Remove the first column as a property during the generation of mapping.json, since the first column is not a property. 
Also clean up the conversion process by removing the unused objects in the old mapping.json.