### PR TITLE
Csv2rdf entity_type order-independent

### DIFF
--- a/csv2rdf/MusicBrainz/mapping.json
+++ b/csv2rdf/MusicBrainz/mapping.json
@@ -9,14 +9,14 @@
     "type-id": "http://musicbrainz.org/doc/Label/Type",
     "genres_name": "https://schema.org/genre",
     "genres_id": "http://www.wikidata.org/prop/direct/P136",
-    "entity_type": [
-        "http://www.wikidata.org/entity/Q2221906",
-        "http://www.wikidata.org/entity/Q1656682",
-        "http://www.wikidata.org/entity/Q188451",
-        "http://www.wikidata.org/entity/Q34379",
-        "http://www.wikidata.org/entity/Q18127",
-        "http://www.wikidata.org/entity/Q15975575"
-    ],
+    "entity_type": {
+        "area.csv": "http://www.wikidata.org/entity/Q2221906",
+        "event.csv": "http://www.wikidata.org/entity/Q1656682",
+        "genre.csv": "http://www.wikidata.org/entity/Q188451",
+        "instrument.csv": "http://www.wikidata.org/entity/Q34379",
+        "label.csv": "http://www.wikidata.org/entity/Q18127",
+        "recording.csv": "http://www.wikidata.org/entity/Q15975575"
+    },
     "event_id": "http://www.wikidata.org/prop/direct/P793",
     "cancelled": "https://musicbrainz.org/doc/Event#cancelled",
     "time": "http://www.wikidata.org/prop/direct/P585",

--- a/csv2rdf/README.md
+++ b/csv2rdf/README.md
@@ -23,16 +23,17 @@ Steps:
     "type-id": "https://musicbrainz.org/doc/Label/Type",
     "genres_name": "https://www.wikidata.org/wiki/Property:P136",
     "genres_id": "https://www.wikidata.org/wiki/Property:P8052",
-    "entity_type": [
-        "https://www.wikidata.org/wiki/Q11500",
-        "https://www.wikidata.org/wiki/Q1656682",
-        "https://www.wikidata.org/wiki/Q34379",
-        "https://www.wikidata.org/wiki/Q18127",
-        "https://www.wikidata.org/wiki/Q155171"
-    ],
+    "entity_type": {
+        "area.csv": "http://www.wikidata.org/entity/Q2221906",
+        "event.csv": "http://www.wikidata.org/entity/Q1656682",
+        "genre.csv": "http://www.wikidata.org/entity/Q188451",
+        "instrument.csv": "http://www.wikidata.org/entity/Q34379",
+        "label.csv": "http://www.wikidata.org/entity/Q18127",
+        "recording.csv": "http://www.wikidata.org/entity/Q15975575"
+    },
     "event_id": "https://www.wikidata.org/wiki/Property:P6423"
 }
-* Object "entity_type" should be a list of types (instances, not properties) with the same order as the order of input files.
+* Object "entity_type" should be a dict of types (instances, not properties) mapped to the filename.
 5. Run csv2rdf_single_subject.py. Example execution:
     python3 csv2rdf_single_subject.py mapping.json area.csv artist.csv genre.csv recording.csv ...
 There can be as many input csv files as needed, and they will be merged into one single out_rdf.ttl file. The "entity_type" should contain the types of entities of these input files respectively.

--- a/csv2rdf/cantus/mapping.json
+++ b/csv2rdf/cantus/mapping.json
@@ -10,5 +10,5 @@
     "cantus_id": "https://cantusdatabase.org/about/id-numbers",
     "indexing_notes": "https://cantusdatabase.org/description/#IndexingNotes",
     "source_description": "http://schema.org/description",
-    "entity_type": ["https://cantusdatabase.org/chant/"]
+    "entity_type": {"reconciled_cantus.csv": "https://cantusdatabase.org/chant/"}
 }

--- a/csv2rdf/csv2rdf_single_subject.py
+++ b/csv2rdf/csv2rdf_single_subject.py
@@ -46,7 +46,7 @@ def convert_csv_to_turtle(filenames: List[str]) -> Graph:
         # If we use the get_relations.py to generate a mapping file, then
         # the ontology_list is guaranteed to have a value.
         try:
-            ontology_type = type_dict[filename]
+            ontology_type = type_dict[filename.rsplit("/", -1)[-1]]
         except IndexError:
             ontology_type = None
 

--- a/csv2rdf/csv2rdf_single_subject.py
+++ b/csv2rdf/csv2rdf_single_subject.py
@@ -40,13 +40,13 @@ def convert_csv_to_turtle(filenames: List[str]) -> Graph:
     g = Graph()
 
     ontology_dict = json.load(open(mapping_filename, "r", encoding='utf-8'))
-    ontology_list = ontology_dict.get("entity_type")
+    type_dict = ontology_dict.get("entity_type")
 
-    for i, filename in enumerate(filenames):
+    for filename in filenames:
         # If we use the get_relations.py to generate a mapping file, then
         # the ontology_list is guaranteed to have a value.
         try:
-            ontology_type = ontology_list[i]
+            ontology_type = type_dict[filename]
         except IndexError:
             ontology_type = None
 

--- a/csv2rdf/simssa/mapping.json
+++ b/csv2rdf/simssa/mapping.json
@@ -1,8 +1,8 @@
 {
-    "entity_type": [
-        "http://www.wikidata.org/entity/Q2188189",
-        "http://www.wikidata.org/entity/Q31464082"
-    ],
+    "entity_type": {
+        "mw_reconciled_WikiID_URI.csv": "http://www.wikidata.org/entity/Q2188189",
+        "sc_reconciled_WikiID_URI.csv": "http://www.wikidata.org/entity/Q31464082"
+    },
     "musical_work_id": "https://db.simssa.ca/musicalworks/",
     "sacred_or_secular": "http://www.wikidata.org/entity/Q9174",
     "source_id": "http://www.wikidata.org/prop/direct/P1896",

--- a/csv2rdf/thesession/mapping.json
+++ b/csv2rdf/thesession/mapping.json
@@ -1,13 +1,13 @@
 {
-    "entity_type": [
-        "http://www.wikidata.org/entity/Q61002",
-        "http://www.wikidata.org/entity/Q1656682",
-        "http://www.wikidata.org/entity/Q273057",
-        "http://www.wikidata.org/entity/Q932410",
-        "http://www.wikidata.org/entity/Q36161",
-        "http://www.wikidata.org/entity/Q1357284",
-        "http://www.wikidata.org/entity/Q170412"
-    ],
+    "entity_type": {
+        "aliases.csv": "http://www.wikidata.org/entity/Q61002",
+        "events.csv": "http://www.wikidata.org/entity/Q1656682",
+        "recordings.csv": "http://www.wikidata.org/entity/Q273057",
+        "sessions.csv": "http://www.wikidata.org/entity/Q932410",
+        "sets.csv": "http://www.wikidata.org/entity/Q36161",
+        "tune-popularity.csv": "http://www.wikidata.org/entity/Q1357284",
+        "tunes.csv": "http://www.wikidata.org/entity/Q170412"
+    },
     "tune_id": "https://thesession.org/tunes",
     "alias": "http://www.wikidata.org/prop/direct/P742",
     "name": "http://www.wikidata.org/prop/direct/P2561",


### PR DESCRIPTION
Now the entity_type object is no longer a list. It's changed to a dict that maps the entity type from Wikidata to the filename.