### PR TITLE
refactor(wikidata_utils.helpers): broaden Wikidata ID regex to support more URL and prefix patterns

### DIFF
--- a/code/wikidata_utils/helpers.py
+++ b/code/wikidata_utils/helpers.py
@@ -7,20 +7,15 @@ import re
 WD_ID_PATTERN = re.compile(
     r"""
     (?:
-        ^\s*
-        |
-        www\.wikidata\.org/wiki/Property:
-        |
-        www\.wikidata\.org/wiki/
-        |
-        www\.wikidata\.org/entity/
-        |
-        www\.wikidata\.org/prop/direct/
+        \bwd: |
+        \bwdt: |
+        https?://www\.wikidata\.org/(?:wiki/Property:|wiki/|entity/|prop/direct/) |
+        (?:\b|\s|"|'|^)
     )
     (Q\d+|P\d+)
-    $
+    (?:\b|\s|"|'|$)
     """,
-    re.VERBOSE
+    re.VERBOSE,
 )
 
 


### PR DESCRIPTION
- Improving flexibility of Wikidata ID extraction across input formats.
    - **Support for TTL files**: useful for upcoming working with ontologies written in TTL files.
    - **Support for TOML files**: needed for subsequent general RDF conversion script pull request.