### PR TITLE
Adding MusicBrainz instrumentation

### DIFF
--- a/code/musicbrainz/convert_to_rdf.py
+++ b/code/musicbrainz/convert_to_rdf.py
@@ -91,9 +91,9 @@ CHUNK_SIZE = 500  # Adjustable chunk size
 # Max number of chunk processing processes to run simultaneously
 MAX_SIMULTANEOUS_CHUNK_WORKERS = 3
 # Max number of subgraph merging threads to run simultaneously
-MAX_SIMULTANEOUS_SUBGRAPH_WORKERS = 2
+MAX_SIMULTANEOUS_SUBGRAPH_WORKERS = 1
 # Max number of graph serializing processes to run simultaneously
-MAX_SIMULTANEOUS_GRAPH_WORKERS = 1
+MAX_SIMULTANEOUS_GRAPH_WORKERS = 2
 # Max number of processes to run simultaneously
 MAX_PROCESSES = min(
     MAX_SIMULTANEOUS_CHUNK_WORKERS + MAX_SIMULTANEOUS_GRAPH_WORKERS, os.cpu_count() or 1

--- a/code/musicbrainz/convert_to_rdf.py
+++ b/code/musicbrainz/convert_to_rdf.py
@@ -91,7 +91,7 @@ CHUNK_SIZE = 500  # Adjustable chunk size
 # Max number of chunk processing processes to run simultaneously
 MAX_SIMULTANEOUS_CHUNK_WORKERS = 3
 # Max number of subgraph merging threads to run simultaneously
-MAX_SIMULTANEOUS_SUBGRAPH_WORKERS = 3
+MAX_SIMULTANEOUS_SUBGRAPH_WORKERS = 2
 # Max number of graph serializing processes to run simultaneously
 MAX_SIMULTANEOUS_GRAPH_WORKERS = 3
 # Max number of processes to run simultaneously

--- a/code/musicbrainz/convert_to_rdf.py
+++ b/code/musicbrainz/convert_to_rdf.py
@@ -529,6 +529,21 @@ def process_entity(
                 # If the target is a MusicBrainz entity, create a URIRef
                 target = URIRef(f"{MB}{target_type}/{target_id}")
 
+        # Handle instrument relationships
+        if (
+            entity_type == "recording"
+            and target_type == "artist"
+            and rel_type == "instrument"
+        ):
+            for inst in relation.get("attribute-ids", {}).values():
+                g.add(
+                    (
+                        subject_uri,
+                        entity_mb_schema["instrument"],
+                        MBIN[inst],
+                    )
+                )
+
         if target and pred_uri:
             # All genre relationships need the genre as a subject
             if target_type == "genre":

--- a/code/musicbrainz/convert_to_rdf.py
+++ b/code/musicbrainz/convert_to_rdf.py
@@ -50,7 +50,7 @@ from isodate.isoerror import ISO8601Error
 from isodate.isodates import parse_date
 from isodate.isodatetime import parse_datetime
 from tqdm import tqdm
-from rdflib import Graph, URIRef, Literal, Namespace
+from rdflib import Graph, ConjunctiveGraph, URIRef, Literal, Namespace
 from rdflib.namespace import XSD, RDF
 import pandas as pd
 import aiofiles
@@ -89,7 +89,8 @@ CHUNK_SIZE = 500  # Adjustable chunk size
 # Max number of chunk processing threads to run simultaneously
 MAX_SIMULTANEOUS_CHUNK_WORKERS = 3
 # Max number of processes to run simultaneously
-MAX_PROCESSES = min(MAX_SIMULTANEOUS_CHUNK_WORKERS, os.cpu_count() or 1)
+# The +1 is for the process that will be serializing the graphs
+MAX_PROCESSES = min(MAX_SIMULTANEOUS_CHUNK_WORKERS + 1, os.cpu_count() or 1)
 MAX_CHUNKS_IN_MEMORY = 120  # Max number of chunks to keep in memory at once
 MAX_SUBGRAPHS_IN_MEMORY = 120  # Max number of subgraphs to keep in memory at once
 
@@ -647,7 +648,7 @@ def process_chunk(
     return g
 
 
-async def subgraph_worker(
+async def chunk_worker(
     chunk_queue,
     subgraph_queue,
     entity_type,
@@ -712,18 +713,14 @@ def merge_subgraph(graph, subgraph):
     graph.commit()  # Commit the changes to the main graph
 
 
-async def graph_worker(
-    subgraph_queue, namespaces, main_graphs, graph_store, subgraph_bar
-):
+async def merge_worker(subgraph_queue, graph_queue, graph_store, subgraph_bar):
     """Worker function to merge subgraphs into the main graph."""
+    graph_num = 0
     if graph_store:
         graph = Graph("Oxigraph")
-        graph.open(f"./store-{len(main_graphs)}", create=True)
+        graph.open(f"./store-{graph_num}", create=True)
     else:
         graph = Graph()
-    for prefix, ns in namespaces.items():
-        graph.bind(prefix, ns)
-    main_graphs.append(graph)
 
     chunk_count = 0
     loop = asyncio.get_event_loop()
@@ -741,38 +738,131 @@ async def graph_worker(
             chunk_count += 1
 
             if graph_store and chunk_count % MAX_CHUNKS_PER_GRAPH == 0:
+                # Save the current graph to the queue
+                if graph_store:
+                    graph.commit()
+                    graph.close()
+                    await graph_queue.put((graph_num, f"./store-{graph_num}"))
+                else:
+                    await graph_queue.put((graph_num, graph))
                 # Start a new graph
+                graph_num += 1
                 graph = Graph("Oxigraph")
-                graph.open(f"./store-{len(main_graphs)}", create=True)
-                for prefix, ns in namespaces.items():
-                    graph.bind(prefix, ns)
-                main_graphs.append(graph)
+                graph.open(f"./store-{graph_num}", create=True)
     except asyncio.CancelledError:
         sigint = True
     except Exception as e:
         with tqdm.get_lock():
             tqdm.write(f"Error merging subgraph: {type(e).__name__}: {e}")
     finally:
+        if not sigint:
+            while not subgraph_queue.empty():
+                subgraph = await subgraph_queue.get()
+                await loop.run_in_executor(None, merge_subgraph, graph, subgraph)
+                subgraph_queue.task_done()
+                with tqdm.get_lock():
+                    subgraph_bar.update(1)
+                chunk_count += 1
+                if graph_store and chunk_count % MAX_CHUNKS_PER_GRAPH == 0:
+                    # Save the current graph to the queue
+                    if graph_store:
+                        graph.commit()
+                        graph.close()
+                        await graph_queue.put((graph_num, f"./store-{graph_num}"))
+                    else:
+                        await graph_queue.put((graph_num, graph))
+                    # Start a new graph
+                    graph_num += 1
+                    graph = Graph("Oxigraph")
+                    graph.open(f"./store-{graph_num}", create=True)
+        if graph_store:
+            graph.commit()
+            graph.close()
+            await graph_queue.put((graph_num, f"./store-{graph_num}"))
+        else:
+            await graph_queue.put((graph_num, graph))
+
+
+def serialize_graph(graph, filename, namespaces):
+    """
+    Serialize the graph to a Turtle file.
+    If a string is given, it is assumed to be the path to the store for the graph.
+    """
+    if isinstance(graph, Graph):
+        for prefix, ns in namespaces.items():
+            graph.bind(prefix, ns)
+        with open(filename, "wb") as f:
+            graph.serialize(f, format="turtle", encoding="utf-8")
+    else:
+        # Use a ConjunctiveGraph to get around the fact that Oxigraph is a quad store
+        # and rdflib's Graph is a triple store, which can cause issues with reopening the graph
+        # due to triples not appearing
+        g = ConjunctiveGraph("Oxigraph")
+        g.open(graph, create=False)
+        for prefix, ns in namespaces.items():
+            g.bind(prefix, ns)
+        with open(filename, "wb") as f:
+            g.serialize(f, format="turtle", encoding="utf-8")
+
+
+async def serialize_worker(
+    entity_type, output_folder, graph_queue, serialize_bar, namespaces, executor
+):
+    """
+    Worker function to serialize graphs.
+    This function runs in a separate process to speed up the serialization.
+    """
+    loop = asyncio.get_event_loop()
+    sigint = False
+    try:
+        while True:
+            i, graph = await graph_queue.get()
+            output_file = output_folder / f"{entity_type}-{i}.ttl"
+            await loop.run_in_executor(
+                executor, serialize_graph, graph, str(output_file), namespaces
+            )
+            # Fully delete the stores
+            if os.path.exists(f"./store-{i}"):
+                for root, dirs, files in os.walk(f"./store-{i}", topdown=False):
+                    for file in files:
+                        os.remove(os.path.join(root, file))
+                    for name in dirs:
+                        os.rmdir(os.path.join(root, name))
+                os.rmdir(f"./store-{i}")
+            graph_queue.task_done()
+            with tqdm.get_lock():
+                serialize_bar.update(1)
+    except asyncio.CancelledError:
+        sigint = True
+    except Exception as e:
+        with tqdm.get_lock():
+            tqdm.write(f"Error serializing graph: {type(e).__name__}: {e}")
+    finally:
         if sigint:
             return
-        while not subgraph_queue.empty():
-            subgraph = await subgraph_queue.get()
-            await loop.run_in_executor(None, merge_subgraph, graph, subgraph)
-            subgraph_queue.task_done()
+        while not graph_queue.empty():
+            i, graph = await graph_queue.get()
+            output_file = output_folder / f"{entity_type}-{i}.ttl"
+            await loop.run_in_executor(
+                executor, serialize_graph, graph, str(output_file), namespaces
+            )
+            # Fully delete the stores
+            if os.path.exists(f"./store-{i}"):
+                for root, dirs, files in os.walk(f"./store-{i}", topdown=False):
+                    for file in files:
+                        os.remove(os.path.join(root, file))
+                    for name in dirs:
+                        os.rmdir(os.path.join(root, name))
+                os.rmdir(f"./store-{i}")
+            graph_queue.task_done()
             with tqdm.get_lock():
-                subgraph_bar.update(1)
-            chunk_count += 1
-            if graph_store and chunk_count % MAX_CHUNKS_PER_GRAPH == 0:
-                # Start a new graph
-                graph = Graph("Oxigraph")
-                graph.open(f"./store-{len(main_graphs)}", create=True)
-                for prefix, ns in namespaces.items():
-                    graph.bind(prefix, ns)
-                main_graphs.append(graph)
+                serialize_bar.update(1)
 
 
-async def get_final_graphs(entity_type, input_file, namespaces, reconciled_mapping):
-    """Main function to process the input file and return the final RDF graph."""
+async def create_graphs(
+    entity_type, input_file, output_folder, namespaces, reconciled_mapping
+):
+    """Main function to process the input file and export the final RDF graphs."""
     with open(input_file, "r", encoding="utf-8") as f:
         total_lines = sum(1 for _ in f)
     total_chunks = (
@@ -790,22 +880,32 @@ async def get_final_graphs(entity_type, input_file, namespaces, reconciled_mappi
         graph_store = False
         print(f"{input_file} is small enough to use an in-memory graph.")
 
-    main_graphs = []
+    # Only use 1 graph if we don't use a graph store
+    if graph_store:
+        graph_count = (
+            total_chunks // MAX_CHUNKS_PER_GRAPH + 1
+            if total_chunks % MAX_CHUNKS_PER_GRAPH != 0
+            else total_chunks // MAX_CHUNKS_PER_GRAPH
+        )
+    else:
+        graph_count = 1
 
-    # Create task queue
+    # Create queues
     chunk_queue = asyncio.Queue(MAX_CHUNKS_IN_MEMORY)
     subgraph_queue = asyncio.Queue(MAX_SUBGRAPHS_IN_MEMORY)
+    graph_queue = asyncio.Queue(graph_count)
 
     # Create the progress bars
     file_bar = tqdm(total=total_lines, desc="Processing lines", position=0)
     chunk_bar = tqdm(total=total_chunks, desc="Processing chunks", position=1)
     subgraph_bar = tqdm(total=total_chunks, desc="Merging subgraphs", position=2)
+    serialize_bar = tqdm(total=graph_count, desc="Saving RDF graphs", position=3)
 
     with ProcessPoolExecutor(max_workers=MAX_PROCESSES) as executor:
         try:
             subgraph_workers = [
                 asyncio.create_task(
-                    subgraph_worker(
+                    chunk_worker(
                         chunk_queue,
                         subgraph_queue,
                         entity_type,
@@ -818,9 +918,22 @@ async def get_final_graphs(entity_type, input_file, namespaces, reconciled_mappi
                 )
                 for _ in range(MAX_SIMULTANEOUS_CHUNK_WORKERS)
             ]
-            merge_worker = asyncio.create_task(
-                graph_worker(
-                    subgraph_queue, namespaces, main_graphs, graph_store, subgraph_bar
+            merge_worker_task = asyncio.create_task(
+                merge_worker(
+                    subgraph_queue,
+                    graph_queue,
+                    graph_store,
+                    subgraph_bar,
+                )
+            )
+            serialize_worker_task = asyncio.create_task(
+                serialize_worker(
+                    entity_type,
+                    output_folder,
+                    graph_queue,
+                    serialize_bar,
+                    namespaces,
+                    executor,
                 )
             )
 
@@ -852,17 +965,25 @@ async def get_final_graphs(entity_type, input_file, namespaces, reconciled_mappi
 
             await subgraph_queue.join()  # Wait for all subgraphs to be processed
 
-            merge_worker.cancel()
+            merge_worker_task.cancel()
 
-            await asyncio.gather(merge_worker)
+            await asyncio.gather(merge_worker_task)
+
+            with tqdm.get_lock():
+                subgraph_bar.refresh()
+
+            await graph_queue.join()  # Wait for all graphs to be serialized
+
+            serialize_worker_task.cancel()
+
+            await asyncio.gather(serialize_worker_task)
 
             file_bar.close()
             chunk_bar.close()
             subgraph_bar.close()
+            serialize_bar.close()
         except KeyboardInterrupt:
             executor.shutdown(wait=False, cancel_futures=True)
-
-    return main_graphs
 
 
 def main(args):
@@ -904,32 +1025,15 @@ def main(args):
         "mbwo": MBWO,
     }
 
-    main_graphs = asyncio.run(
-        get_final_graphs(
+    asyncio.run(
+        create_graphs(
             entity_type,
             input_file,
+            output_folder,
             namespaces,
             reconciled_mapping,
         )
     )
-
-    # Save the final result
-    for i, main_graph in enumerate(tqdm(main_graphs, desc="Saving RDF graphs")):
-        output_file = output_folder / f"{entity_type}-{i}.ttl"
-        tqdm.write(f"Saving RDF data to: {output_file}")
-        with open(output_file, "wb") as f:
-            main_graph.serialize(f, format="turtle", encoding="utf-8")
-        tqdm.write(f"Successfully saved RDF data to: {output_file}")
-        main_graph.close()
-
-        # Fully delete the stores
-        if os.path.exists(f"./store-{i}"):
-            for root, dirs, files in os.walk(f"./store-{i}", topdown=False):
-                for file in files:
-                    os.remove(os.path.join(root, file))
-                for name in dirs:
-                    os.rmdir(os.path.join(root, name))
-            os.rmdir(f"./store-{i}")
 
 
 if __name__ == "__main__":

--- a/code/musicbrainz/convert_to_rdf.py
+++ b/code/musicbrainz/convert_to_rdf.py
@@ -93,7 +93,7 @@ MAX_SIMULTANEOUS_CHUNK_WORKERS = 3
 # Max number of subgraph merging threads to run simultaneously
 MAX_SIMULTANEOUS_SUBGRAPH_WORKERS = 2
 # Max number of graph serializing processes to run simultaneously
-MAX_SIMULTANEOUS_GRAPH_WORKERS = 3
+MAX_SIMULTANEOUS_GRAPH_WORKERS = 1
 # Max number of processes to run simultaneously
 MAX_PROCESSES = min(
     MAX_SIMULTANEOUS_CHUNK_WORKERS + MAX_SIMULTANEOUS_GRAPH_WORKERS, os.cpu_count() or 1
@@ -845,6 +845,7 @@ async def serialize_worker(
                     for name in dirs:
                         os.rmdir(os.path.join(root, name))
                 os.rmdir(f"./store-{i}")
+            graph = None  # Clear the graph reference
             graph_queue.task_done()
             with tqdm.get_lock():
                 serialize_bar.update(1)

--- a/code/musicbrainz/rdf_conversion_config/mappings.json
+++ b/code/musicbrainz/rdf_conversion_config/mappings.json
@@ -57,7 +57,8 @@
         "event": "http://www.wikidata.org/prop/direct/P585"
     },
     "instrument": {
-        "instrument": "http://www.wikidata.org/prop/direct/P279"
+        "instrument": "http://www.wikidata.org/prop/direct/P279",
+        "recording": "http://www.wikidata.org/prop/direct/P870"
     },
     "address": {
         "place": "http://www.wikidata.org/prop/direct/P6375"

--- a/doc/musicbrainz/rdf_conversion.md
+++ b/doc/musicbrainz/rdf_conversion.md
@@ -42,7 +42,7 @@ The below rules are to conform with RDF standards and with Wikidata standards
 - The script uses `asyncio.Queue` queues to send data between the steps, and the queues have size limits to limit pending operations to avoid using up a large amount of memory on pending tasks
 - Settings for queue sizes, as well as the number of parallel processes are in global variables at the beginning of the script.
 - The amount of chunk processing workers is set to 3 because that's what I found to be the most efficient, since ultimately you are limited by the subgraph merging.
-- The amount of subgraph merging workers is set to 3. This will be refined if needed.
+- The amount of subgraph merging workers is set to 2 to reduce memory usage to avoid crashes.
 - The amount of graph serializing workers is set to 3 since graphs tend to queue up since they are quite big.
 - For ease of reading, the fields are processed in alphabetical order in the `process_entity` function.
 - Errors within an entity are caught, and the problematic entity is safely skipped. The same logic is also applied to chunks.

--- a/doc/musicbrainz/rdf_conversion.md
+++ b/doc/musicbrainz/rdf_conversion.md
@@ -39,9 +39,10 @@ The below rules are to conform with RDF standards and with Wikidata standards
   - Converting chunks into RDF subgraphs
   - Merging the subgraphs into larger graphs that will be serialized to turtle
   - Serializing the graphs to the turtle output files
-- The script uses `asyncio` queues to send data between the steps, and the queues have size limits to limit pending operations to avoid using up a large amount of memory on pending tasks
+- The script uses `asyncio.Queue` queues to send data between the steps, and the queues have size limits to limit pending operations to avoid using up a large amount of memory on pending tasks
 - Settings for queue sizes, as well as the number of parallel processes are in global variables at the beginning of the script.
 - The amount of chunk processing workers is set to 3 because that's what I found to be the most efficient, since ultimately you are limited by the subgraph merging.
+- The amount of subgraph merging workers is set to 3. This will be refined if needed.
 - The amount of graph serializing workers is set to 3 since graphs tend to queue up since they are quite big.
 - For ease of reading, the fields are processed in alphabetical order in the `process_entity` function.
 - If you call `Literal(...)` with `XSD:date` as datatype, it will eventually call the `parse_date` isodate function to validate the format. However, `parse_date` is called after the construction of the `Literal`, making any exception it raises impossible to catch. This is why I call the `parse_date` function and pass its value to the constructor in the `convert_date` function, thus allowing any exceptions to be caught and dealt with.

--- a/doc/musicbrainz/rdf_conversion.md
+++ b/doc/musicbrainz/rdf_conversion.md
@@ -42,8 +42,8 @@ The below rules are to conform with RDF standards and with Wikidata standards
 - The script uses `asyncio.Queue` queues to send data between the steps, and the queues have size limits to limit pending operations to avoid using up a large amount of memory on pending tasks
 - Settings for queue sizes, as well as the number of parallel processes are in global variables at the beginning of the script.
 - The amount of chunk processing workers is set to 3 because that's what I found to be the most efficient, since ultimately you are limited by the subgraph merging.
-- The amount of subgraph merging workers is set to 2 to reduce memory usage to avoid crashes.
-- The amount of graph serializing workers is set to 1 since the graph serialization process is quite memory-intensive.
+- The amount of subgraph merging workers is set to 1 to reduce memory usage to avoid crashes, it can be raised if you have more than 16GB of RAM.
+- The amount of graph serializing workers is set to 2 to avoid graphs queueing up since it is a very slow process.
 - For ease of reading, the fields are processed in alphabetical order in the `process_entity` function.
 - Errors within an entity are caught, and the problematic entity is safely skipped. The same logic is also applied to chunks.
 - Unexpected errors that cause workers to crash are logged, the problematic task is marked as complete so that other workers don't run into it, and the worker safely exits.

--- a/doc/musicbrainz/rdf_conversion.md
+++ b/doc/musicbrainz/rdf_conversion.md
@@ -45,6 +45,8 @@ The below rules are to conform with RDF standards and with Wikidata standards
 - The amount of subgraph merging workers is set to 3. This will be refined if needed.
 - The amount of graph serializing workers is set to 3 since graphs tend to queue up since they are quite big.
 - For ease of reading, the fields are processed in alphabetical order in the `process_entity` function.
+- Errors within an entity are caught, and the problematic entity is safely skipped
+- Unexpected errors that cause workers to crash are logged, the problematic task is marked as complete so that other workers don't run into it, and the worker safely exits.
 - If you call `Literal(...)` with `XSD:date` as datatype, it will eventually call the `parse_date` isodate function to validate the format. However, `parse_date` is called after the construction of the `Literal`, making any exception it raises impossible to catch. This is why I call the `parse_date` function and pass its value to the constructor in the `convert_date` function, thus allowing any exceptions to be caught and dealt with.
 - The same situation applies to the `convert_datetime` function with the `XSD:dateTime` datatype and the `parse_datetime` isodate function.
 - The dictionary containing property mappings for the data fields and URLs was moved into a JSON file, located in [`code/musicbrainz/rdf_conversion_config/mappings.json`](/code/musicbrainz/rdf_conversion_config/mappings.json). The dictionary contains the internal dictionary of a `MappingSchema` object serialized into JSON by Python's built-in JSON module. As such, the outermost dictionary's are the properties, the innermost dictionary's keys are the source types (with `null` as a wildcard), and the values are the full URIs to the properties.

--- a/doc/musicbrainz/rdf_conversion.md
+++ b/doc/musicbrainz/rdf_conversion.md
@@ -49,6 +49,7 @@ The below rules are to conform with RDF standards and with Wikidata standards
 - The `event` entity type's `setlist` field seems to contain pre-rendered data about the setlist, which makes it difficult to parse. Furthermore, the same data is also located in the `relations` field, and as such, the `setlist` field is ignored during the RDF conversion process.
 - The release group entity type is spelled `release-group` almost everywhere. Yet, in the `target-type` field under `relationships`, and as the name of a field under `relationships`, it is exceptionally spelled as `release_group`. The RDF conversion script's approach is to convert all underscores to dashes before processing.
 - As per this [forum thread](https://community.metabrainz.org/t/recording-json-dumps-incomplete/322708) and this [bug report](https://tickets.metabrainz.org/browse/MBS-9433), the data dump for the `recording` entities only contains "standalone" recordings, i.e. recordings that are not associated with any release, and all other recordings are located in the `release` data dump, as a list in each `release` entity.
+- Data on instrumentation for recordings is stored as an attribute of the ["instrument" artist-recording relationship](https://musicbrainz.org/relationship/59054b12-01ac-43ee-a618-285fd397e461), not as a direct relationship or as a field of the `recording` entity
 
 ## Identifiers to other databases
 

--- a/doc/musicbrainz/rdf_conversion.md
+++ b/doc/musicbrainz/rdf_conversion.md
@@ -41,6 +41,8 @@ The below rules are to conform with RDF standards and with Wikidata standards
   - Serializing the graphs to the turtle output files
 - The script uses `asyncio` queues to send data between the steps, and the queues have size limits to limit pending operations to avoid using up a large amount of memory on pending tasks
 - Settings for queue sizes, as well as the number of parallel processes are in global variables at the beginning of the script.
+- The amount of chunk processing workers is set to 3 because that's what I found to be the most efficient, since ultimately you are limited by the subgraph merging.
+- The amount of graph serializing workers is set to 3 since graphs tend to queue up since they are quite big.
 - For ease of reading, the fields are processed in alphabetical order in the `process_entity` function.
 - If you call `Literal(...)` with `XSD:date` as datatype, it will eventually call the `parse_date` isodate function to validate the format. However, `parse_date` is called after the construction of the `Literal`, making any exception it raises impossible to catch. This is why I call the `parse_date` function and pass its value to the constructor in the `convert_date` function, thus allowing any exceptions to be caught and dealt with.
 - The same situation applies to the `convert_datetime` function with the `XSD:dateTime` datatype and the `parse_datetime` isodate function.

--- a/doc/musicbrainz/rdf_conversion.md
+++ b/doc/musicbrainz/rdf_conversion.md
@@ -43,7 +43,7 @@ The below rules are to conform with RDF standards and with Wikidata standards
 - Settings for queue sizes, as well as the number of parallel processes are in global variables at the beginning of the script.
 - The amount of chunk processing workers is set to 3 because that's what I found to be the most efficient, since ultimately you are limited by the subgraph merging.
 - The amount of subgraph merging workers is set to 2 to reduce memory usage to avoid crashes.
-- The amount of graph serializing workers is set to 3 since graphs tend to queue up since they are quite big.
+- The amount of graph serializing workers is set to 1 since the graph serialization process is quite memory-intensive.
 - For ease of reading, the fields are processed in alphabetical order in the `process_entity` function.
 - Errors within an entity are caught, and the problematic entity is safely skipped. The same logic is also applied to chunks.
 - Unexpected errors that cause workers to crash are logged, the problematic task is marked as complete so that other workers don't run into it, and the worker safely exits.

--- a/doc/musicbrainz/rdf_conversion.md
+++ b/doc/musicbrainz/rdf_conversion.md
@@ -34,8 +34,14 @@ The below rules are to conform with RDF standards and with Wikidata standards
 - The graph will not use disk storage if the input file is less than 1GB in size. This is a configurable limit in the script.
 - Additionally, if a file is large enough to use disk storage, the output graph will be split into a separate graph every 2000 data chunks. This value can be changed, but was set to 2000 so that the release file (~9.8k chunks) will be split into 5 graphs with some extra space. This is useful to upload the data to Virtuoso as it doesn't seem to handle files bigger than ~2GB very well, and makes copying and moving the files easier.
 - By default, the script will ignore any data types that already have a corresponding file in the output directory. This is useful in the event that the program crashes and you only need to rerun the RDF conversion on the data that wasn't processed instead of the entire input directory.
+- The script is made to run as many things in parallel as possible, to reduce the amount of times that a single piece of data is duplicated in memory. As such, the 4 following tasks all run in parallel:
+  - Reading the file and creating chunks of 500 lines
+  - Converting chunks into RDF subgraphs
+  - Merging the subgraphs into larger graphs that will be serialized to turtle
+  - Serializing the graphs to the turtle output files
+- The script uses `asyncio` queues to send data between the steps, and the queues have size limits to limit pending operations to avoid using up a large amount of memory on pending tasks
 - Settings for queue sizes, as well as the number of parallel processes are in global variables at the beginning of the script.
-- For ease of reading, the fields are processed in alphabetical order in the `process_line` function.
+- For ease of reading, the fields are processed in alphabetical order in the `process_entity` function.
 - If you call `Literal(...)` with `XSD:date` as datatype, it will eventually call the `parse_date` isodate function to validate the format. However, `parse_date` is called after the construction of the `Literal`, making any exception it raises impossible to catch. This is why I call the `parse_date` function and pass its value to the constructor in the `convert_date` function, thus allowing any exceptions to be caught and dealt with.
 - The same situation applies to the `convert_datetime` function with the `XSD:dateTime` datatype and the `parse_datetime` isodate function.
 - The dictionary containing property mappings for the data fields and URLs was moved into a JSON file, located in [`code/musicbrainz/rdf_conversion_config/mappings.json`](/code/musicbrainz/rdf_conversion_config/mappings.json). The dictionary contains the internal dictionary of a `MappingSchema` object serialized into JSON by Python's built-in JSON module. As such, the outermost dictionary's are the properties, the innermost dictionary's keys are the source types (with `null` as a wildcard), and the values are the full URIs to the properties.

--- a/doc/musicbrainz/rdf_conversion.md
+++ b/doc/musicbrainz/rdf_conversion.md
@@ -45,7 +45,7 @@ The below rules are to conform with RDF standards and with Wikidata standards
 - The amount of subgraph merging workers is set to 3. This will be refined if needed.
 - The amount of graph serializing workers is set to 3 since graphs tend to queue up since they are quite big.
 - For ease of reading, the fields are processed in alphabetical order in the `process_entity` function.
-- Errors within an entity are caught, and the problematic entity is safely skipped
+- Errors within an entity are caught, and the problematic entity is safely skipped. The same logic is also applied to chunks.
 - Unexpected errors that cause workers to crash are logged, the problematic task is marked as complete so that other workers don't run into it, and the worker safely exits.
 - If you call `Literal(...)` with `XSD:date` as datatype, it will eventually call the `parse_date` isodate function to validate the format. However, `parse_date` is called after the construction of the `Literal`, making any exception it raises impossible to catch. This is why I call the `parse_date` function and pass its value to the constructor in the `convert_date` function, thus allowing any exceptions to be caught and dealt with.
 - The same situation applies to the `convert_datetime` function with the `XSD:dateTime` datatype and the `parse_datetime` isodate function.


### PR DESCRIPTION
Adds instrumentation data to the graphs produced by the MusicBrainz RDF conversion script
Also updated the RDF conversion script to serialize graphs in parallel with all the other processes, instead of doing it all at the end
Updated the error handling procedure for the workers so that the workers mark the erroneous task as complete and log the error before safely exiting

Closes #436 